### PR TITLE
xcvrd: Remove SFP API object when SFP is removed

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1735,6 +1735,12 @@ class SfpStateUpdateTask(threading.Thread):
                                     media_settings_parser.notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper, self.port_mapping)
                                     transceiver_dict.clear()
                             elif value == sfp_status_helper.SFP_STATUS_REMOVED:
+                                # Remove the SFP API object for this physical port
+                                try:
+                                    sfp = platform_chassis.get_sfp(int(key))
+                                    sfp.remove_xcvr_api()
+                                except (NotImplementedError, AttributeError) as e:
+                                    helper_logger.log_error(f"Failed to remove xcvr api for port {key}: {str(e)}")
                                 helper_logger.log_notice("{}: Got SFP removed event".format(logical_port))
                                 state_port_table = self.xcvr_table_helper.get_state_port_tbl(asic_index)
                                 state_port_table.set(logical_port, [(NPU_SI_SETTINGS_SYNC_STATUS_KEY, NPU_SI_SETTINGS_DEFAULT_VALUE)])


### PR DESCRIPTION
Depends on: https://github.com/sonic-net/sonic-platform-common/pull/562

When an SFP is physically removed from a port, the SFP API object should be removed from the sfp_obj_dict to prevent stale object references and ensure proper cleanup. This change ensures that when the SFP status is detected as removed, the corresponding SFP API object is properly deleted from the dictionary.

#### Description
<!--
     Describe your changes in detail
-->
Add check for SFP_STATUS_REMOVED in SfpStateUpdateTask.
Remove SFP API object from sfp_obj_dict when SFP is removed.
Add unit test to verify SFP object removal functionality.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
Make sure SFP API object is removed when SFP removed, so cmis cache can also be re-created.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Tested with config reload.