### PR TITLE
Test xcvrd api id

### DIFF
--- a/sonic-xcvrd/xcvrd/dom/dom_mgr.py
+++ b/sonic-xcvrd/xcvrd/dom/dom_mgr.py
@@ -39,7 +39,7 @@ class DomInfoUpdateTask(threading.Thread):
         {'APPL_DB': 'PORT_TABLE', 'FILTER': ['flap_count']},
     ]
 
-    def __init__(self, namespaces, port_mapping, sfp_obj_dict, main_thread_stop_event, skip_cmis_mgr):
+    def __init__(self, namespaces, port_mapping, sfp_obj_dict, main_thread_stop_event, skip_cmis_mgr, platform_chassis):
         threading.Thread.__init__(self)
         self.name = "DomInfoUpdateTask"
         self.exc = None
@@ -50,6 +50,7 @@ class DomInfoUpdateTask(threading.Thread):
         self.namespaces = namespaces
         self.skip_cmis_mgr = skip_cmis_mgr
         self.sfp_obj_dict = sfp_obj_dict
+        self.platform_chassis = platform_chassis
         self.link_change_affected_ports = {}
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
         self.xcvrd_utils = XCVRDUtils(self.sfp_obj_dict, helper_logger)
@@ -143,6 +144,9 @@ class DomInfoUpdateTask(threading.Thread):
     def post_port_sfp_firmware_info_to_db(self, logical_port_name, port_mapping, table,
                                 stop_event=threading.Event(), firmware_info_cache=None):
         for physical_port, physical_port_name in xcvrd.get_physical_port_name_dict(logical_port_name, port_mapping).items():
+            sfp = self.platform_chassis.get_sfp(physical_port)
+            api = sfp.get_xcvr_api()
+            self.log_notice("{}: DomInfoUpdateTask api id = {}".format(logical_port_name, id(api)))
             if stop_event.is_set():
                 break
 

--- a/sonic-xcvrd/xcvrd/sff_mgr.py
+++ b/sonic-xcvrd/xcvrd/sff_mgr.py
@@ -412,6 +412,7 @@ class SffManagerTask(threading.Thread):
                 try:
                     # Skip if XcvrApi is not supported
                     api = sfp.get_xcvr_api()
+                    self.log_notice("{}: SffManagerTask api id = {}".format(lport, id(api)))
                     if api is None:
                         self.log_error(
                             "{}: skipping sff_mgr since no xcvr api!".format(lport))

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1735,6 +1735,12 @@ class SfpStateUpdateTask(threading.Thread):
                                     media_settings_parser.notify_media_setting(logical_port, transceiver_dict, self.xcvr_table_helper, self.port_mapping)
                                     transceiver_dict.clear()
                             elif value == sfp_status_helper.SFP_STATUS_REMOVED:
+                                # Remove the SFP API object for this physical port
+                                try:
+                                    sfp = platform_chassis.get_sfp(int(key))
+                                    sfp.remove_xcvr_api()
+                                except (NotImplementedError, AttributeError) as e:
+                                    helper_logger.log_error(f"Failed to remove xcvr api for port {key}: {str(e)}")
                                 helper_logger.log_notice("{}: Got SFP removed event".format(logical_port))
                                 state_port_table = self.xcvr_table_helper.get_state_port_tbl(asic_index)
                                 state_port_table.set(logical_port, [(NPU_SI_SETTINGS_SYNC_STATUS_KEY, NPU_SI_SETTINGS_DEFAULT_VALUE)])


### PR DESCRIPTION
Test xcvrd api

In those classes, they are same:
CmisManagerTask
SfpStateUpdateTask
DomInfoUpdateTask

SffManagerTask seems not used in our platform.

/var/log/syslog.1:2025 May 15 14:38:33.547541 r-leopard-72 NOTICE pmon#xcvrd[4774]: CMIS: Ethernet4: CmisManagerTask api id = 140210175924240
/var/log/syslog.1:2025 May 15 14:38:33.929098 r-leopard-72 NOTICE pmon#xcvrd[4774]: CMIS: Ethernet0: CmisManagerTask api id = 140210175924240
/var/log/syslog.1:2025 May 15 14:38:43.670556 r-leopard-72 ERR pmon#xcvrd[4774]: Ethernet4: SfpStateUpdateTask api id = 140210175924240
/var/log/syslog.1:2025 May 15 14:38:43.803641 r-leopard-72 ERR pmon#xcvrd[4774]: Ethernet0: SfpStateUpdateTask api id = 140210175924240
/var/log/syslog.1:2025 May 15 14:39:51.697231 r-leopard-72 NOTICE pmon#DomInfoUpdateTask[4774]: Ethernet0: DomInfoUpdateTask api id = 140210175924240

